### PR TITLE
Fix color leaking into uncolored lines

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,9 +21,9 @@ import (
 )
 
 var (
-	success = color.New(color.FgGreen)
-	skipped = color.New(color.FgYellow)
-	fail    = color.New(color.FgHiRed)
+	success = color.FgGree
+	skipped = color.FgYellow
+	fail    = color.FgHiRed
 )
 
 const paletteEnv = "GOTEST_PALETTE"
@@ -75,40 +75,30 @@ func consume(wg *sync.WaitGroup, r io.Reader) {
 	}
 }
 
-var c *color.Color
-
 func parse(line string) {
 	trimmed := strings.TrimSpace(line)
+	defer color.Unset()
 
 	switch {
-	case strings.HasPrefix(trimmed, "=== RUN"):
-		fallthrough
-	case strings.HasPrefix(trimmed, "?"):
-		c = nil
-
 	// success
 	case strings.HasPrefix(trimmed, "--- PASS"):
 		fallthrough
 	case strings.HasPrefix(trimmed, "ok"):
 		fallthrough
 	case strings.HasPrefix(trimmed, "PASS"):
-		c = success
+		color.Set(success)
 
 	// skipped
 	case strings.HasPrefix(trimmed, "--- SKIP"):
-		c = skipped
+		color.Set(skipped)
 
 	// failure
 	case strings.HasPrefix(trimmed, "--- FAIL"):
 		fallthrough
 	case strings.HasPrefix(trimmed, "FAIL"):
-		c = fail
+		color.Set(fail)
 	}
 
-	if c == nil {
-		fmt.Printf("%s\n", line)
-		return
-	}
 	c.Printf("%s\n", line)
 }
 
@@ -136,10 +126,10 @@ func setPalette() {
 		return
 	}
 	if c, ok := colors[vals[0]]; ok {
-		fail = color.New(c)
+		fail = c
 	}
 	if c, ok := colors[vals[1]]; ok {
-		success = color.New(c)
+		success = c
 	}
 }
 


### PR DESCRIPTION
Using the default terminal color should be the default behavior rather
than predicated upon line content.

Currently, color is only unset when a line contains `=== RUN` or `?`. 

Color should be unset by default and only set for content we intend to be colorized.